### PR TITLE
Add Next.js API proxy routes for database service

### DIFF
--- a/app/api/login/route.ts
+++ b/app/api/login/route.ts
@@ -1,0 +1,6 @@
+import { NextRequest } from "next/server"
+import { proxyDatabaseRequest } from "@/lib/server/proxy-db"
+
+export async function POST(request: NextRequest) {
+  return proxyDatabaseRequest(request, "/login")
+}

--- a/app/api/signup/route.ts
+++ b/app/api/signup/route.ts
@@ -1,0 +1,6 @@
+import { NextRequest } from "next/server"
+import { proxyDatabaseRequest } from "@/lib/server/proxy-db"
+
+export async function POST(request: NextRequest) {
+  return proxyDatabaseRequest(request, "/signup")
+}

--- a/app/api/update-profile/route.ts
+++ b/app/api/update-profile/route.ts
@@ -1,0 +1,6 @@
+import { NextRequest } from "next/server"
+import { proxyDatabaseRequest } from "@/lib/server/proxy-db"
+
+export async function POST(request: NextRequest) {
+  return proxyDatabaseRequest(request, "/update-profile")
+}

--- a/app/api/user/[uid]/route.ts
+++ b/app/api/user/[uid]/route.ts
@@ -1,0 +1,18 @@
+import { NextRequest, NextResponse } from "next/server"
+import { proxyDatabaseRequest } from "@/lib/server/proxy-db"
+
+type RouteContext = {
+  params: {
+    uid: string
+  }
+}
+
+export async function GET(request: NextRequest, context: RouteContext) {
+  const { uid } = context.params
+
+  if (!uid) {
+    return NextResponse.json({ error: "User ID is required" }, { status: 400 })
+  }
+
+  return proxyDatabaseRequest(request, `/user/${uid}`)
+}

--- a/components/Dashboard.tsx
+++ b/components/Dashboard.tsx
@@ -132,7 +132,7 @@ export const Dashboard: React.FC<DashboardProps> = ({
 
       console.log("Sending update data:", updateData);
 
-      const response = await fetch("http://localhost:3000/update-profile", {
+      const response = await fetch("/api/update-profile", {
         method: "POST",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify(updateData),
@@ -178,9 +178,7 @@ export const Dashboard: React.FC<DashboardProps> = ({
     setIsLoadingSession(true);
     setIsLoadingExercises(true);
     try {
-      const response = await fetch(
-        `http://localhost:3000/user/${currentUser.uid}`
-      );
+      const response = await fetch(`/api/user/${currentUser.uid}`);
       console.log("Response status:", response.status);
 
       if (response.ok) {

--- a/hooks/useAuth.ts
+++ b/hooks/useAuth.ts
@@ -36,7 +36,7 @@ export const useAuth = () => {
 
   const fetchUserProfile = async (uid: string) => {
     try {
-      const response = await fetch(`http://localhost:3000/user/${uid}`)
+      const response = await fetch(`/api/user/${uid}`)
       if (response.ok) {
         const userData = await response.json()
         

--- a/lib/auth.ts
+++ b/lib/auth.ts
@@ -2,7 +2,7 @@ import { User } from "./types"
 
 export const login = async (email: string, password: string): Promise<User> => {
   try {
-    const response = await fetch("http://localhost:3000/login", {
+    const response = await fetch("/api/login", {
       method: "POST",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify({ email, password }),
@@ -36,7 +36,7 @@ export const signup = async (formData: {
   gender: string
 }): Promise<User> => {
   try {
-    const response = await fetch("http://localhost:3000/signup", {
+    const response = await fetch("/api/signup", {
       method: "POST",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify(formData),
@@ -63,7 +63,7 @@ export const signup = async (formData: {
 }
 export const getCurrentUser = async (uid: string): Promise<User> => {
   try {
-    const response = await fetch(`http://localhost:3000/user/${uid}`)
+    const response = await fetch(`/api/user/${uid}`)
     const data = await response.json()
 
     if (response.ok) {

--- a/lib/server/proxy-db.ts
+++ b/lib/server/proxy-db.ts
@@ -1,0 +1,43 @@
+import { NextRequest, NextResponse } from "next/server"
+
+const DATABASE_SERVICE_URL = process.env.DATABASE_SERVICE_URL
+
+const READ_BODY_METHODS = new Set(["POST", "PUT", "PATCH", "DELETE"])
+
+export async function proxyDatabaseRequest(
+  request: NextRequest,
+  path: string
+): Promise<NextResponse> {
+  if (!DATABASE_SERVICE_URL) {
+    return NextResponse.json(
+      { error: "Database service URL is not configured." },
+      { status: 500 }
+    )
+  }
+
+  const search = request.nextUrl.search
+  const targetUrl = new URL(`${path}${search}`, DATABASE_SERVICE_URL)
+
+  const headers = new Headers(request.headers)
+  headers.set("host", targetUrl.host)
+  headers.delete("content-length")
+
+  const init: RequestInit = {
+    method: request.method,
+    headers,
+    redirect: "manual",
+  }
+
+  if (READ_BODY_METHODS.has(request.method)) {
+    const body = await request.arrayBuffer()
+    init.body = body
+  }
+
+  const response = await fetch(targetUrl, init)
+  const responseHeaders = new Headers(response.headers)
+
+  return new NextResponse(response.body, {
+    status: response.status,
+    headers: responseHeaders,
+  })
+}


### PR DESCRIPTION
## Summary
- add Next.js API route handlers that proxy authentication and profile requests to the database service
- centralize request forwarding logic in a reusable server-side helper to preserve method, headers, and body
- update client authentication utilities and dashboard to call the new relative /api endpoints

## Testing
- pnpm lint *(fails: unable to download pnpm 10.14.0 due to network restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_68cea37566c4832bb4b2f37e636b0a6c