### PR TITLE
Proxy websocket traffic through Next.js rewrites

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,10 @@
+# Youth
+
+## WebSocket Configuration
+
+The application proxies WebSocket connections through Next.js so the browser can connect to the same origin that serves the app. Configure the following environment variables in production deployments:
+
+- `WS_SERVICE_URL` – Absolute URL of the upstream WebSocket service (e.g. `wss://socket.example.com` or `http://localhost:8765`). This endpoint receives the upgraded connection from the rewrite defined in `next.config.mjs`.
+- `NEXT_PUBLIC_WS_PATH` (optional) – Relative path on the Next.js app that should forward to the upstream service. Defaults to `/api/ws`.
+
+When running locally, ensure `WS_SERVICE_URL` points to your WebSocket server so the built-in rewrite can proxy upgrade requests correctly.

--- a/hooks/useSession.ts
+++ b/hooks/useSession.ts
@@ -38,7 +38,7 @@ export const useSession = (
   const initializeAudioClient = async () => {
     try {
       const { default: AudioClient } = await import("../lib/audio-client.js")
-      const audioClient = new AudioClient("ws://localhost:8765")
+      const audioClient = new AudioClient()
 
       // Set the user ID before connecting
       if (currentUser?.uid) {

--- a/lib/audio-client.js
+++ b/lib/audio-client.js
@@ -2,9 +2,25 @@
  * Audio processing client for bidirectional audio AI communication
  */
 
+const DEFAULT_WS_PATH = process.env.NEXT_PUBLIC_WS_PATH || "/api/ws"
+
+const buildDefaultServerUrl = () => {
+  if (typeof window === "undefined") {
+    return undefined
+  }
+
+  try {
+    const url = new URL(DEFAULT_WS_PATH, window.location.origin)
+    url.protocol = window.location.protocol === "https:" ? "wss:" : "ws:"
+    return url.toString()
+  } catch (error) {
+    console.error("Failed to construct default WebSocket URL", error)
+    return undefined
+  }
+}
 
 class AudioClient {
-  constructor(serverUrl = "ws://localhost:8765") {
+  constructor(serverUrl = buildDefaultServerUrl()) {
     this.serverUrl = serverUrl
     this.ws = null
     this.recorder = null
@@ -54,6 +70,13 @@ class AudioClient {
     // Reset reconnect attempts if this is a new connection
     if (this.reconnectAttempts > this.maxReconnectAttempts) {
       this.reconnectAttempts = 0
+    }
+
+    if (!this.serverUrl) {
+      const error = new Error("WebSocket server URL is not configured")
+      console.error(error.message)
+      this.onError(error)
+      return Promise.reject(error)
     }
 
     return new Promise((resolve, reject) => {

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -1,4 +1,26 @@
 /** @type {import('next').NextConfig} */
+const normalizePath = (path) => {
+  const withLeadingSlash = path ? (path.startsWith("/") ? path : `/${path}`) : "/api/ws"
+  if (withLeadingSlash.length > 1 && withLeadingSlash.endsWith("/")) {
+    return withLeadingSlash.slice(0, -1)
+  }
+  return withLeadingSlash
+}
+
+const normalizeDestination = (url) => {
+  if (!url) return url
+  if (url.startsWith("ws://")) {
+    return `http://${url.slice(5)}`
+  }
+  if (url.startsWith("wss://")) {
+    return `https://${url.slice(6)}`
+  }
+  return url
+}
+
+const wsProxyPath = normalizePath(process.env.NEXT_PUBLIC_WS_PATH)
+const wsServiceUrl = normalizeDestination(process.env.WS_SERVICE_URL)
+
 const nextConfig = {
   eslint: {
     ignoreDuringBuilds: true,
@@ -8,6 +30,18 @@ const nextConfig = {
   },
   images: {
     unoptimized: true,
+  },
+  async rewrites() {
+    if (!wsServiceUrl) {
+      return []
+    }
+
+    return [
+      {
+        source: wsProxyPath,
+        destination: wsServiceUrl,
+      },
+    ]
   },
 }
 


### PR DESCRIPTION
## Summary
- add a configurable rewrite so `/api/ws` (or `NEXT_PUBLIC_WS_PATH`) proxies to `WS_SERVICE_URL`
- derive the audio client's default socket URL from the routed path and let session setup use it
- document the websocket environment variables required in deployment

## Testing
- `pnpm lint` *(fails: package manager download blocked by network proxy)*

------
https://chatgpt.com/codex/tasks/task_e_68cea378038c832bb1b299184c1fab4a