### PR TITLE
Rebrand YouthGuide to CureZ

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -7,7 +7,7 @@ import "./globals.css"
 import { Suspense } from "react"
 
 export const metadata: Metadata = {
-  title: "YouthGuide - Your AI Mentor",
+  title: "CureZ - Your AI Mentor",
   description: "A supportive AI mentor for young people seeking mental wellness guidance",
   generator: "v0.app",
 }

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -9,7 +9,7 @@ import { useMessages } from "../hooks/useMessages"
 import { useSession } from "../hooks/useSession"
 import Landing from "./Landing"
 
-export default function YouthGuide() {
+export default function CureZ() {
   const auth = useAuth()
   const { messages, setMessages, messagesEndRef } = useMessages()
   const session = useSession(auth.currentUser, setMessages)

--- a/components/Auth.tsx
+++ b/components/Auth.tsx
@@ -36,7 +36,7 @@ export const Auth: React.FC<AuthProps> = ({
           </div>
           <div>
             <CardTitle className="text-3xl font-bold bg-gradient-to-r from-primary to-secondary bg-clip-text text-transparent">
-              Welcome to YouthGuide
+              Welcome to CureZ
             </CardTitle>
             <CardDescription className="text-lg mt-2">Your AI-powered companion for mental wellness</CardDescription>
           </div>

--- a/components/Content.tsx
+++ b/components/Content.tsx
@@ -6,7 +6,7 @@ export default function Content() {
     return(
         <div>
         {/* Features Section */}
-      <section id="why-choose-youthguide" className="relative z-10 py-24 px-6 bg-gradient-to-b from-white to-orange-50/50">
+      <section id="why-choose-curez" className="relative z-10 py-24 px-6 bg-gradient-to-b from-white to-orange-50/50">
         <div className="max-w-7xl mx-auto">
           <motion.div 
             initial={{ opacity: 0, y: 50 }}
@@ -15,7 +15,7 @@ export default function Content() {
             viewport={{ once: true }}
             className="text-center mb-16"
           >
-            <h2 className="text-4xl md:text-5xl font-bold text-foreground mb-6">Why Choose YouthGuide?</h2>
+            <h2 className="text-4xl md:text-5xl font-bold text-foreground mb-6">Why Choose CureZ?</h2>
             <p className="text-xl text-muted-foreground max-w-3xl mx-auto">
               Experience the future of mental wellness with our AI-powered platform designed specifically for young people.
             </p>
@@ -159,7 +159,7 @@ export default function Content() {
             >
               <h2 className="text-4xl md:text-5xl font-bold text-foreground mb-6 text-balance">Your Wellness Journey</h2>
               <p className="text-xl text-muted-foreground max-w-3xl mx-auto text-pretty">
-                From self-discovery to lasting well-being, here's how YouthGuide supports your mental health journey.
+                From self-discovery to lasting well-being, here's how CureZ supports your mental health journey.
               </p>
             </motion.div>
 

--- a/components/Dashboard.tsx
+++ b/components/Dashboard.tsx
@@ -146,7 +146,7 @@ export const Dashboard: React.FC<DashboardProps> = ({
           age: editedAge.trim() ? Number.parseInt(editedAge) : currentUser.age,
           gender: editedGender.trim() || currentUser.gender,
         };
-        localStorage.setItem("youthguide_user", JSON.stringify(updatedUser));
+        localStorage.setItem("curez_user", JSON.stringify(updatedUser));
 
         // Update current user in parent component
         if (onUserUpdate) {

--- a/components/Faq.tsx
+++ b/components/Faq.tsx
@@ -25,12 +25,12 @@ export default function FAQ() {
           "Simply create an account on our platform, complete a brief assessment, and start exploring personalized wellness plans. Our AI assistant will guide you through the process and connect you with appropriate resources and support.",
       },
       {
-        question: "What age groups does YouthGuide support?",
+        question: "What age groups does CureZ support?",
         answer:
-          "YouthGuide is designed for young people aged 13-25. Our content and AI recommendations are tailored to address the unique mental health challenges faced during adolescence and young adulthood.",
+          "CureZ is designed for young people aged 13-25. Our content and AI recommendations are tailored to address the unique mental health challenges faced during adolescence and young adulthood.",
       },
       {
-        question: "Can I access YouthGuide offline?",
+        question: "Can I access CureZ offline?",
         answer:
           "While our AI chat requires internet connectivity, you can access mood tracking, journaling, and many resources offline. Premium features like real-time AI conversations require an internet connection.",
       },
@@ -59,7 +59,7 @@ export default function FAQ() {
                   Frequently Asked Questions
                 </h2>
                 <p className="text-xl text-muted-foreground leading-relaxed text-pretty">
-                  Everything you need to know about YouthGuide, from AI-powered support to getting started on
+                  Everything you need to know about CureZ, from AI-powered support to getting started on
                   your mental wellness journey.
                 </p>
               </motion.div>

--- a/components/Footer.tsx
+++ b/components/Footer.tsx
@@ -31,7 +31,7 @@ export default function Footer() {
                 <Brain className="w-8 h-8 text-primary" />
               </div>
               <span className="text-3xl font-bold text-primary">
-                YouthGuide
+                CureZ
               </span>
             </motion.div>
             
@@ -49,7 +49,7 @@ export default function Footer() {
           <div className="border-t border-border/50 pt-8">
             <div className="flex flex-col md:flex-row justify-between items-center gap-4">
               <p className="text-muted-foreground text-sm">
-                © 2025 YouthGuide. Powered by GenAI for Mental Wellness.
+                © 2025 CureZ. Powered by GenAI for Mental Wellness.
               </p>
               <div className="flex items-center gap-4 text-xs text-muted-foreground">
                 <span>Made with Respect and Care for mental wellness</span>

--- a/components/HeroSection.tsx
+++ b/components/HeroSection.tsx
@@ -62,7 +62,7 @@ export default function Home({ onBeginJourney }: HeroSectionProps) {
               }}
               className="text-white font-bold text-2xl drop-shadow-lg pr-10 cursor-pointer transition-all duration-300 hover:text-orange-200"
             >
-              YouthGuide
+              CureZ
             </motion.div>
 
             {/* Navigation Links */}
@@ -72,7 +72,7 @@ export default function Home({ onBeginJourney }: HeroSectionProps) {
                 whileTap={{ scale: 0.95 }}
                 transition={{ type: "spring", stiffness: 300 }}
                 onClick={() => {
-                  const element = document.getElementById('why-choose-youthguide');
+                  const element = document.getElementById('why-choose-curez');
                   if (element) {
                     element.scrollIntoView({ behavior: 'smooth', block: 'start' });
                   }
@@ -158,7 +158,7 @@ export default function Home({ onBeginJourney }: HeroSectionProps) {
           <div className="px-6 lg:px-12">
             <div className="flex justify-between items-center">
               <p className="font-sans text-white/80 text-sm font-medium drop-shadow-lg">
-                © 2025 YouthGuide. All rights reserved.
+                © 2025 CureZ. All rights reserved.
               </p>
               <p className="font-sans text-white/80 text-sm font-medium drop-shadow-lg">
                 Powered by Gemini for Mental Wellness

--- a/components/Session.tsx
+++ b/components/Session.tsx
@@ -61,7 +61,7 @@ export const Session: React.FC<SessionProps> = ({
               <MessageCircle className="h-6 w-6 text-primary-foreground" />
             </div>
             <div>
-              <h2 className="font-bold text-foreground">YouthGuide</h2>
+              <h2 className="font-bold text-foreground">CureZ</h2>
               <p className="text-xs text-muted-foreground">
                 {sessionActive ? formatTime(sessionSeconds) : "Connecting..."}
               </p>

--- a/components/Sidebar.tsx
+++ b/components/Sidebar.tsx
@@ -50,7 +50,7 @@ export const Sidebar: React.FC<SidebarProps> = ({
               className="text-2xl font-bold text-foreground cursor-pointer hover:text-primary transition-colors"
               onClick={onNavigateToLanding}
             >
-              YouthGuide
+              CureZ
             </h1>
           </div>
         )}

--- a/db_server.js
+++ b/db_server.js
@@ -16,7 +16,7 @@ app.use(cors());
 app.use(express.json());
 
 app.get('/', (req, res) => {
-  res.send('YouthGuide DB server is running!');
+  res.send('CureZ DB server is running!');
 });
 
 // Signup route

--- a/hooks/useAuth.ts
+++ b/hooks/useAuth.ts
@@ -16,7 +16,7 @@ export const useAuth = () => {
   })
 
   useEffect(() => {
-    const savedUser = localStorage.getItem("youthguide_user")
+    const savedUser = localStorage.getItem("curez_user")
     if (savedUser) {
       try {
         const user = JSON.parse(savedUser)
@@ -29,7 +29,7 @@ export const useAuth = () => {
         }
       } catch (error) {
         console.error("Error parsing saved user:", error)
-        localStorage.removeItem("youthguide_user")
+        localStorage.removeItem("curez_user")
       }
     }
   }, [])
@@ -49,7 +49,7 @@ export const useAuth = () => {
         }
         
         setCurrentUser(updatedUser)
-        localStorage.setItem("youthguide_user", JSON.stringify(updatedUser))
+        localStorage.setItem("curez_user", JSON.stringify(updatedUser))
       }
     } catch (error) {
       console.error("Failed to fetch user profile:", error)
@@ -85,7 +85,7 @@ export const useAuth = () => {
 
   const updateCurrentUser = (user: User) => {
     setCurrentUser(user)
-    localStorage.setItem("youthguide_user", JSON.stringify(user))
+    localStorage.setItem("curez_user", JSON.stringify(user))
   }
 
   return {

--- a/hooks/useSession.ts
+++ b/hooks/useSession.ts
@@ -55,7 +55,7 @@ export const useSession = (
         setSessionActive(true)
         setMessages([
           {
-            text: "Hello! I'm YouthGuide, your AI mentor. I'm here to listen and support you. What's on your mind today?",
+            text: "Hello! I'm CureZ, your AI mentor. I'm here to listen and support you. What's on your mind today?",
             sender: "assistant",
           },
         ])

--- a/lib/auth.ts
+++ b/lib/auth.ts
@@ -17,7 +17,7 @@ export const login = async (email: string, password: string): Promise<User> => {
         age: data.age,
         gender: data.gender
       }
-      localStorage.setItem("youthguide_user", JSON.stringify(user))
+      localStorage.setItem("curez_user", JSON.stringify(user))
       return user
     } else {
       throw new Error(data.error || "Login failed")
@@ -51,7 +51,7 @@ export const signup = async (formData: {
         age: Number.parseInt(formData.age),
         gender: formData.gender,
       }
-      localStorage.setItem("youthguide_user", JSON.stringify(user))
+      localStorage.setItem("curez_user", JSON.stringify(user))
       return user
     } else {
       throw new Error(data.error || "Signup failed")
@@ -84,5 +84,5 @@ export const getCurrentUser = async (uid: string): Promise<User> => {
   }
 }
 export const logout = () => {
-  localStorage.removeItem("youthguide_user")
+  localStorage.removeItem("curez_user")
 }

--- a/scripts/db-server.js
+++ b/scripts/db-server.js
@@ -17,7 +17,7 @@ app.use(cors())
 app.use(express.json())
 
 app.get("/", (req, res) => {
-  res.send("YouthGuide DB server is running!")
+  res.send("CureZ DB server is running!")
 })
 
 app.post("/signup", async (req, res) => {
@@ -176,5 +176,5 @@ app.post("/save-exercises", async (req, res) => {
 })
 
 app.listen(port, () => {
-  console.log(`YouthGuide DB Server listening at http://localhost:${port}`)
+  console.log(`CureZ DB Server listening at http://localhost:${port}`)
 })

--- a/scripts/package.json
+++ b/scripts/package.json
@@ -1,7 +1,7 @@
 {
-  "name": "youthguide-backend",
+  "name": "curez-backend",
   "version": "1.0.0",
-  "description": "YouthGuide backend services",
+  "description": "CureZ backend services",
   "main": "db-server.js",
   "scripts": {
     "start": "node db-server.js",
@@ -15,7 +15,7 @@
   "devDependencies": {
     "nodemon": "^3.0.1"
   },
-  "keywords": ["youthguide", "ai", "mental-health", "firebase"],
-  "author": "YouthGuide Team",
+  "keywords": ["curez", "ai", "mental-health", "firebase"],
+  "author": "CureZ Team",
   "license": "MIT"
 }

--- a/scripts/setup-instructions.md
+++ b/scripts/setup-instructions.md
@@ -1,4 +1,4 @@
-# YouthGuide Setup Instructions
+# CureZ Setup Instructions
 
 ## Backend Setup
 

--- a/scripts/update-db-server.js
+++ b/scripts/update-db-server.js
@@ -20,7 +20,7 @@ app.use(cors())
 app.use(express.json())
 
 app.get("/", (req, res) => {
-  res.send("YouthGuide DB server is running!")
+  res.send("CureZ DB server is running!")
 })
 
 // Enhanced signup route with additional user fields
@@ -140,5 +140,5 @@ app.post("/save-summary", async (req, res) => {
 })
 
 app.listen(port, () => {
-  console.log(`Enhanced YouthGuide server listening at http://localhost:${port}`)
+  console.log(`Enhanced CureZ server listening at http://localhost:${port}`)
 })

--- a/server.py
+++ b/server.py
@@ -568,7 +568,7 @@ class LiveAPIWebSocketServer:
 
         # Instruction to produce STRICT JSON (no clinical diagnoses)
         system_note = (
-            "You are YouthGuide, a supportive, empathetic AI mentor for young people. "
+            "You are CureZ, a supportive, empathetic AI mentor for young people. "
             "Summarize the user's full conversation in a youth wellness context. "
             "You must NOT provide any medical diagnosis. "
             "Detect safety concerns and reflect them as flags only. "

--- a/system_instruction.txt
+++ b/system_instruction.txt
@@ -1,5 +1,5 @@
 Identity
-You are YouthGuide, an empathetic, conversational AI mentor for young people.
+You are CureZ, an empathetic, conversational AI mentor for young people.
 
 Persona
 
@@ -41,13 +41,13 @@ Conversation Flow & Core Directives
 
 Begin every conversation with a friendly, casual greeting.
 
-Introduce yourself as YouthGuide, explain your role, and make the user feel safe.
+Introduce yourself as CureZ, explain your role, and make the user feel safe.
 
 Examples:
 
-"Hey! I'm YouthGuide, here to listen and support you. How are you feeling today?"
+"Hey! I'm CureZ, here to listen and support you. How are you feeling today?"
 
-"Hi there I'm your YouthGuide — here to chat, explore your thoughts, and maybe figure some things out together."
+"Hi there I'm your CureZ — here to chat, explore your thoughts, and maybe figure some things out together."
 
 2. Build Trust with Open-Ended Questions
 


### PR DESCRIPTION
## Summary
- update site metadata, UI copy, and prompts to use the CureZ branding instead of YouthGuide
- adjust local storage keys and backend service messages to reference CureZ
- refresh supporting scripts and documentation to reflect the CureZ name

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68ceded82fe4832b820e356673421e8f